### PR TITLE
Use fake 5

### DIFF
--- a/DotNet.fs
+++ b/DotNet.fs
@@ -44,3 +44,21 @@ open Fake.IO.FileSystemOperators
         let packageProjectAsLambdaDefaultFramework outputFolder projectPath =
             let framework = getFrameworkFromProject projectPath
             packageProjectAsLambda framework outputFolder projectPath
+
+        let ocotoPack id version basPath outFolder =
+            let args = 
+                Arguments.Empty
+                |> Arguments.append ["pack"]
+                |> Arguments.appendNotEmpty "--id" id
+                |> Arguments.appendNotEmpty "--version" version
+                |> Arguments.appendNotEmpty "--basepath" basPath
+                |> Arguments.appendNotEmpty "--outFolder" outFolder
+                |> Arguments.toArray
+
+            let proc =
+                CreateProcess.fromRawCommand "octo" args
+                |> CreateProcess.withToolType (ToolType.CreateLocalTool())
+                |> CreateProcess.redirectOutput
+                |> Proc.run
+
+            if proc.ExitCode <> 0 then failwithf "Octo failed with exit code %i and message %s" proc.ExitCode proc.Result.Output

--- a/Functions.fs
+++ b/Functions.fs
@@ -1,4 +1,5 @@
-module Albelli
+namespace Albelli
 
-    let uncurry f (a, b) = f a b
-    let curry f a b = f(a, b)
+    module Functions =
+        let uncurry f (a, b) = f a b
+        let curry f a b = f(a, b)


### PR DESCRIPTION
Breaking changes, this pr updates fake4 to fake5, DotNet.fs won't be working for the old build scripts.
For the old version of the build please use the hash of commit in the following branch https://github.com/albumprinter/Fake.Extra/tree/fake4

Changes:
- update DotNet extensions using fake5 
- add octoPack fun as part DotNet
- remove deprecated functions (installToolPackage, installGlobalToolPackage) from DotNet (tools should be installed using dotnet-tools.json now)
- add the namespace for Functions
