### PR TITLE
Update DockerCli extensions with fake 5

### DIFF
--- a/DockerCli.fs
+++ b/DockerCli.fs
@@ -1,9 +1,45 @@
 namespace Albelli
 
 open Fake
+open Fake.Core
 
-    module DockerCli =
+       module DockerCli =
 
-        let runDockerCommand command =
-            let result = Shell.Exec ("docker", command)
-            if result <> 0 then failwithf "Docker command failed %s" command
+        let login (username: string) (password: string) (url: string) =
+            let args = 
+                Arguments.Empty
+                |> Arguments.append ["login"]
+                |> Arguments.appendNotEmpty "-u" username
+                |> Arguments.appendNotEmpty "-p" password 
+                |> Arguments.append [url]
+                |> Arguments.toArray
+            let proc =
+                CreateProcess.fromRawCommand "docker" args
+                |> CreateProcess.redirectOutput
+                |> Proc.run
+            if proc.ExitCode <> 0 then failwithf "docker login failed with exit code %i and message %s" proc.ExitCode proc.Result.Output
+        
+        let build (dockerImageTag: string) (outputDirectory: string) =
+            let args = 
+                Arguments.Empty
+                |> Arguments.append ["build"]
+                |> Arguments.appendNotEmpty "-f" "Dockerfile"
+                |> Arguments.appendNotEmpty "-t" dockerImageTag 
+                |> Arguments.append [outputDirectory]
+                |> Arguments.toArray
+            let proc =
+                CreateProcess.fromRawCommand "docker" args
+                |> CreateProcess.redirectOutput
+                |> Proc.run
+            if proc.ExitCode <> 0 then failwithf "docker build failed with exit code %i and message %s" proc.ExitCode proc.Result.Output
+       
+        let push (dockerImageTag: string) =
+            let args = 
+                Arguments.Empty
+                |> Arguments.append ["push"; dockerImageTag]
+                |> Arguments.toArray
+            let proc =
+                CreateProcess.fromRawCommand "docker" args
+                |> CreateProcess.redirectOutput
+                |> Proc.run
+            if proc.ExitCode <> 0 then failwithf "docker push failed with exit code %i and message %s" proc.ExitCode proc.Result.Output


### PR DESCRIPTION
In addition to https://github.com/albumprinter/Fake.Extra/pull/3
The old version will be available in https://github.com/albumprinter/Fake.Extra/tree/fake4

Changes:
- update DockerCli extensions using fake5 