### PR TITLE
Get assembly name

### DIFF
--- a/DotNet.fs
+++ b/DotNet.fs
@@ -16,6 +16,12 @@ open Fake.IO.FileSystemOperators
             System.IO.File.ReadAllText projectPath
             |> fun x -> x.Contains "<PropertyGroup Label=\"EcsMainProject\" />"
 
+        let getAssemblyName (projectPath : string) : string =
+            let xPath = "/*[local-name()='Project']/*[local-name()='PropertyGroup']/*[local-name()='AssemblyName']"
+            projectPath
+            |> Fake.Core.Xml.loadDoc
+            |> Fake.Core.Xml.selectXPathValue xPath []   
+
         let packageProjectAsLambda lambdaFramework outputFolder (projectPath : string) =
             let projectDirectory = System.IO.Path.GetDirectoryName projectPath
             let projectName = System.IO.Path.GetFileName projectDirectory


### PR DESCRIPTION
Add method get assembly name, is going to be used to get the name of the main assembly here https://github.com/albumprinter/ECOM-Templates-Lambda/blob/master/src/content/EcsFargateApp/build.fsx#L195 
currently, during the build, there is run.sh file is generated which contains the command "dotnet App.dll", but if project name Api.csproj and assembly name Albelli.Domain.Api run.sh will contain the wrong command, in order to fix that I want to use getAssemblyName