### PR TITLE
Add architecture customization feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+/.ionide/*


### PR DESCRIPTION
The lambda by default packing for `x86_64` architecture. Amazon announced `arm64` architecture, so we want to specify that.

Proposed change:
* Add architecture customization feature